### PR TITLE
fix: waci-didcomm spec generation

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -7,8 +7,8 @@ QR Codes and Links for credential centric wallet interactions.
 ## Getting Started
 
 ```
-git clone git@github.com:hellobloom/wallet-credential-interactions.git
-cd wallet-credential-interactions
+git clone git@github.com:decentralized-identity/waci-didcomm.git
+cd waci-didcomm/spec
 npm i
 npm run build
 npx serve ./build

--- a/spec/specs.json
+++ b/spec/specs.json
@@ -12,18 +12,6 @@
         "account": "decentralized-identity",
         "repo": "waci-presentation-exchange"
       }
-    },
-    {
-      "title": "Wallet And Credential Interactions",
-      "spec_directory": "./v0.1",
-      "output_path": "./build/v0.1",
-      "logo": "https://rawcdn.githack.com/decentralized-identity/decentralized-identity.github.io/a3ca39717e440302d1fd99a796e7f00e1c42eb2d/images/logo-flat.svg",
-      "logo_link": "https://identity.foundation",
-      "source": {
-        "host": "github",
-        "account": "decentralized-identity",
-        "repo": "waci-presentation-exchange"
-      }
-    }   
+    }
   ]
 }


### PR DESCRIPTION
specs.json file wasn't updated during the removal of v0.1 spec in https://github.com/decentralized-identity/waci-didcomm/commit/bdb1bcea6ade219c6c754846be10f54c8ff0c47f

closes #28 